### PR TITLE
Remove default page image.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 body_class: page_template
-image: header.jpg
 ---
 {% if page.image %}
 <div id="feature_image">


### PR DESCRIPTION
The `{% if page.image %}` code would always evaluate to true because this `page.html` layout had `page` set.  This change allows pages to have header images or not.
