### PR TITLE
fix twitter share links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,7 @@ body_class: post-template
         <span aria-hidden="true" data-icon="S"></span>
         <strong>Share</strong>
       </a>
-      <a href="http://twitter.com/share?text={{ page.title | xml_encode }}&url={{ page.url prepend: site.baseurl }}" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;" id="btn_comment" class="btn" target="_blank">
+      <a href="http://twitter.com/share?text={{ page.title | cgi_escape }}&url={{ site.url }}{{ page.url prepend: site.baseurl }}" onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;" id="btn_comment" class="btn" target="_blank">
         <span aria-hidden="true" data-icon="C"></span> Comment on Twitter
       </a>
     </menu>


### PR DESCRIPTION
- Use cgi escaping rather than xml encoding, otherwise the URLs don't get encoded appropriately.  To see this issue, use "&" within a title.
- Add site.url to the link used in the twitter share link such that the site works under "jekyll s" and still has useful links
