### PR TITLE
Fixed an invalid URL to Jekyll official page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
             <div class="details">
                 <h4><a href="{{ site.url }}" class="url n">{{ site.title }}</a></h4>
                 <a href="{{ site.baseurl | prepend: site.url }}" class="js-remove-domain-schema">{{ site.url }}{{ site.baseurl }}</a><br>
-                <span>Published with <a href="https://jekyllrb.org">Jekyll</a></span><br>
+                <span>Published with <a href="https://jekyllrb.com">Jekyll</a></span><br>
                 <span><a href='https://github.com/vormwald/joon'>Source code</a></span>
             </div>
         </div>


### PR DESCRIPTION
Hi. I believe "jekyllrb.org" is not the right URL, "jekyllrb.com" probably is.
